### PR TITLE
Fix iOS Alignment y-coordinate for the bottom case.

### DIFF
--- a/spine-ios/Sources/Spine/BoundsProvider.swift
+++ b/spine-ios/Sources/Spine/BoundsProvider.swift
@@ -151,7 +151,7 @@ public enum Alignment: Int {
         switch self {
         case .topLeft, .topCenter, .topRight: return -1.0
         case .centerLeft, .center, .centerRight: return 0.0
-        case .bottomLeft, .bottomCenter, .bottomRight: return -1.0
+        case .bottomLeft, .bottomCenter, .bottomRight: return 1.0
         }
     }
 }


### PR DESCRIPTION
Cross-checked with its Android counterpart.